### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -21,7 +21,7 @@ setAlarm	KEYWORD2
 activeTimer	KEYWORD2
 setTimer	KEYWORD2
 getTimer	KEYWORD2
-setClockOut KEYWORD2
+setClockOut	KEYWORD2
 getClockOut	KEYWORD2
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords